### PR TITLE
Fixed usage of ALSOROOT so that we can compile if it's not defined

### DIFF
--- a/src/execlog/module.c
+++ b/src/execlog/module.c
@@ -52,6 +52,7 @@ MODULE_PARM_DESC(whitelist, " A coma separated list of strings that contains"
 		 " The format of the string must be '${executable}|${argv_start}'."
 		 " The |${argv_start} part is optional.");
 
+#ifdef ALSOROOT
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 36)
 module_param_call(whitelist_include_root, &whitelist_root_param_set, &whitelist_root_param_get, NULL, 0600);
 #else /* LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 36) */
@@ -59,6 +60,7 @@ module_param_cb(whitelist_include_root, &whitelist_root_param, NULL, 0600);
 #endif /* LINUX_VERSION_CODE ? KERNEL_VERSION(2, 6, 36) */
 MODULE_PARM_DESC(whitelist_include_root, "A boolean indicating if root actions"
 		 " should be whitelisted like actions from other users or not.");
+#endif /* ALSOROOT */
 
 /************************************/
 /*             MODULE DEF           */

--- a/src/execlog/whitelist.c
+++ b/src/execlog/whitelist.c
@@ -20,7 +20,6 @@ static struct white_process* whiterow_from_string(char *str);
 static int is_already_whitelisted(struct white_process *head, struct white_process *new_row);
 static char * whitelist_print(struct white_process *row, char * buf, size_t *avail);
 
-#define ALSOROOT 1
 #include "whitelist_helper.c"
 
 /* Separator for the whitelisting */
@@ -110,8 +109,10 @@ is_whitelisted(const char *filename, const char *argv_start, size_t argv_size)
 
 	read_lock_irqsave(&whitelist_rwlock, flags);
 
+#ifdef ALSOROOT
 	if ((!also_root) && current_is_root())
 		goto whitelisted;
+#endif /* ALSOROOT */
 
 	row = whitelist;
 	while (row != NULL) {

--- a/src/execlog/whitelist.h
+++ b/src/execlog/whitelist.h
@@ -9,6 +9,7 @@
 
 #define WHITELISTED 1
 #define NOT_WHITELISTED 0
+#define ALSOROOT 1
 
 /* Probes need to resolve those absolute path.
  * For memory reason, those path lentgh must be bounded.
@@ -18,11 +19,15 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 36)
 int whitelist_param_set(const char *buf, struct kernel_param *kp);
 int whitelist_param_get(char *buffer, struct kernel_param *kp);
+#ifdef ALSOROOT
 int whitelist_root_param_set(const char *buf, struct kernel_param *kp);
 int whitelist_root_param_get(char *buffer, struct kernel_param *kp);
+#endif /* ALSOROOT */
 #else /* LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 36) */
 extern const struct kernel_param_ops whitelist_param;
+#ifdef ALSOROOT
 extern const struct kernel_param_ops whitelist_root_param;
+#endif /* ALSOROOT */
 #endif /* if LINUX_VERSION_CODE ? KERNEL_VERSION(2, 6, 36) */
 
 int is_whitelisted(const char *filename, const char *argv_start, size_t argv_size);


### PR DESCRIPTION
Not sure that this fix is what needs to be done, but from my review of the last 3 commits, the only thing I found is that the usage of the macro ALSOROOT does not seem to be consistent.
I've tried to make it consistent, although I'm not sure whether a better solution would not be to remove it entirely. Will we ever compile without it ?
Note that I did not try a compilation of my fix ....
